### PR TITLE
fix: force exact numeric sum - simplex projection

### DIFF
--- a/src/project.jl
+++ b/src/project.jl
@@ -16,6 +16,7 @@ function σsimplex(x::AbstractVector{T}, σ::Real) where {T<:Real}
     ρ = maximum((1:n)[μ - (cumsum(μ) .- σ) ./ (1:n) .> zero(T)])
     θ = (sum(μ[1:ρ]) - σ) / ρ
     w = max.(x .- θ, zero(T))
+    w[end] += σ - sum(w)
     return w
 end
 

--- a/test/project.jl
+++ b/test/project.jl
@@ -14,6 +14,10 @@
         x = Float64[-1, 0, 0]
         σ = 5
         @test σsimplex(x, σ) ≈ [1, 2, 2]  # Scale up
+        
+        x = Float64[23133337391432116]
+        σ = 652174.7265297174
+        @test sum(σsimplex(x, σ)) ≈ σ  # exact
     end
 
     @testset "gssp" begin


### PR DESCRIPTION
To fix the bug discovered in graphprotocol/allocation-optimizer#32

There is a small numeric error to performing simplex projection
```
x = [2.3133337391432116e16]      # vector to project
σ = 652174.7265297174                # sum (simplex goal)
sum(w) = 652176.0                        # resulted vector sum
```
To quickly deal with the issue we modify the last element to remove the overshoot 